### PR TITLE
fix(ssim): correct SSIMLoss input scaling by multiplying with 255

### DIFF
--- a/basicgs/losses/basic_loss.py
+++ b/basicgs/losses/basic_loss.py
@@ -147,7 +147,7 @@ class SSIMLoss(nn.Module):
             weight (Tensor, optional): of shape (N, C, H, W). Element-wise weights. Default: None.
         """
         pred = pred.clip(None, 1)
-        l = (1 - _ssim_map_pth(pred, target))
+        l = (1 - _ssim_map_pth(pred * 255., target * 255.))
         l = weight_reduce_loss(l, weight, reduction=self.reduction)
         return self.loss_weight * l
 


### PR DESCRIPTION
SSIMLoss previously passed [0,1]-scaled tensors directly into _ssim_map_pth. However, the SSIM calculation inside uses c1 and c2 constants defined with 255 scaling, leading to a mismatch.